### PR TITLE
chore: Remove RIP-7560 address config

### DIFF
--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -78,9 +78,6 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 			EIP1559Elasticity:        eip1559Elasticity,
 			EIP1559DenominatorCanyon: &eip1559DenomCanyon,
 		},
-		EntryPointAddress:     common.HexToAddress("0x0000000000000000000000000000000000007560"),
-		NonceManagerAddress:   common.HexToAddress("0x4200000000000000000000000000000000000024"),
-		DeployerCallerAddress: common.HexToAddress("0x00000000000000000000000000000000ffff7560"),
 	}
 
 	gasLimit := config.L2GenesisBlockGasLimit


### PR DESCRIPTION
# Description

Remove RIP-7560 address config.

It will be managed as a separate code in GETH.

Related PR: https://github.com/kroma-network/7560-geth/pull/2